### PR TITLE
make cc_module_binary executable

### DIFF
--- a/cc_module/private/cc_module.bzl
+++ b/cc_module/private/cc_module.bzl
@@ -301,4 +301,5 @@ cc_module_binary = rule(
     toolchains = ["@bazel_tools//tools/cpp:toolchain_type"],
     incompatible_use_toolchain_transition = True,
     fragments = ["cpp"],
+    executable = True,
 )


### PR DESCRIPTION
Hello, I just tried out this repo and noticed that I could not 'bazel run' the examples. This should fix it.