### PR TITLE
Create MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,1 @@
+bazel_dep(name = "rules_cc", version = "0.1.1")


### PR DESCRIPTION
Recent bazel versions require MODULE.bazel

bazel_dep(name = "rules_cc", version = "0.1.1")

