### PR TITLE
Clang only works if module is cppm, not ixx: rename hello.ixx to hello.cppm

### DIFF
--- a/example/hello-world/hello.cppm
+++ b/example/hello-world/hello.cppm
@@ -1,4 +1,4 @@
-// hello.ixx
+// hello.cppm
 export module hello;
 
 import <iostream>;


### PR DESCRIPTION
TODO: Also need to update example/hello-world/BUILD

line 5:

    src = "hello.cppm", # instead of "hello.ixx"